### PR TITLE
Added raw data to output for buffer access

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -388,7 +388,9 @@ class LdapClient extends EventEmitter {
         let referrals = [];
         return new Promise((resolve, reject) => {
             response.on('searchEntry', entry => {
-                entries.push(entry.object);
+                const obj = entry.object;
+                obj.raw = entry.raw;
+                entries.push(obj);
             });
             response.on('searchReference', referral => {
                 referrals = referrals.concat(referral.uris);


### PR DESCRIPTION
Raw data is needed in order to access buffer objects (profile pics in my case).

Buffer data can now be accessed by `object.raw.profilePhoto`, etc, instead of strings in `object.profilePhoto`.

Taking advantage of a few upstream features/ resolved issues:

ldapjs/node-ldapjs#107
ldapjs/node-ldapjs@2435d1c/lib/messages/search_entry.js#L63 ldapjs/node-ldapjs#290