### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,7 @@ export interface Client extends EventEmitter {
 
   // Additional methods
   searchReturnAll(base: string, options?: SearchOptions, controls?: Control | Array<Control>): Promise<{
-    entries: Array<SearchEntryObject>,
+    entries: Array<SearchEntry>,
     referrals: Array<SearchReference>
   }>
 


### PR DESCRIPTION
There is a mistake in type definition. Entries are SearchEntry, not SearchEntryObject (which was the type returns by the deprecated .object accessor)