### PR TITLE
Fix SearchEntry import in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import {
   Control,
   createClient as _createClient,
   SearchCallbackResponse,
-  SearchEntryObject,
+  SearchEntry,
   SearchOptions,
   SearchReference
 } from 'ldapjs'


### PR DESCRIPTION
SearchEntry type was fixed in #10, but the type itself was never imported into d.ts